### PR TITLE
Fix grammar issue causing jshint to fail

### DIFF
--- a/public/js/store.js
+++ b/public/js/store.js
@@ -1242,7 +1242,7 @@ $(window).ready(function () {
                                                                     xtype: 'textfield',
                                                                     fieldLabel: v.title,
                                                                     name: v.name,
-                                                                    value: (records.length === 1 ) ? (Ext.decode(records[0].data.meta)[v.name] || v.default) : null
+                                                                    value: (records.length === 1 ) ? (Ext.decode(records[0].data.meta)[v.name] || v["default"]) : null
                                                                 }
                                                             )
                                                             break;
@@ -1252,7 +1252,7 @@ $(window).ready(function () {
                                                                     xtype: 'checkbox',
                                                                     fieldLabel: v.title,
                                                                     name: v.name,
-                                                                    checked: (records.length === 1 ) ? ((Ext.decode(records[0].data.meta)[v.name] !== undefined) ? Ext.decode(records[0].data.meta)[v.name] : v.default) : false
+                                                                    checked: (records.length === 1 ) ? ((Ext.decode(records[0].data.meta)[v.name] !== undefined) ? Ext.decode(records[0].data.meta)[v.name] : v["default"]) : false
                                                                 }
                                                             )
                                                             break;
@@ -1270,7 +1270,7 @@ $(window).ready(function () {
                                                                     triggerAction: 'all',
                                                                     name: v.name,
                                                                     fieldLabel: v.title,
-                                                                    value: (records.length === 1 ) ? ((Ext.decode(records[0].data.meta)[v.name]) || v.default) : null
+                                                                    value: (records.length === 1 ) ? ((Ext.decode(records[0].data.meta)[v.name]) || v["default"]) : null
                                                                 }
                                                             )
                                                             break;


### PR DESCRIPTION
I was getting this issue after a recent commit.

```js
Running "jshint:all" (jshint) task

   public/js/store.js
   1245 | value: (records.length === 1 ) ? (Ext.decode(records[0].data.meta)[v.name] || v.default) : null
                                                                                                                                                             ^ Expected an identifier and instead saw 'default' (a reserved word).
   1255 | checked: (records.length === 1 ) ? ((Ext.decode(records[0].data.meta)[v.name] !== undefined) ? Ext.decode(records[0].data.meta)[v.name] : v.default) : false
                                                                                                                                                                                                                         ^ Expected an identifier and instead saw 'default' (a reserved word).
   1273 |  value: (records.length === 1 ) ? ((Ext.decode(records[0].data.meta)[v.name]) || v.default) : null
                                                                                                                                                               ^ Expected an identifier and instead saw 'default' (a reserved word).

>> 3 errors in 24 files
Warning: Task "jshint:all" failed. Use --force to continue.

Aborted due to warnings.
ERROR: Service 'gc2core' failed to build: The command '/bin/sh -c cd /var/www/geocloud2 && 	npm install && 	grunt production' returned a non-zero code: 3
```