### PR TITLE
migration and database user format

### DIFF
--- a/app/api/v2/Admin.php
+++ b/app/api/v2/Admin.php
@@ -86,7 +86,7 @@ class Admin extends Controller
         $response = [];
         $data = [];
 
-        $arr = ["mapcentia", "gc2scheduler", Database::getDb()];
+        $arr = ["mapcentia", "gc2scheduler", "template_geocloud", Database::getDb()];
         foreach ($arr as $db) {
             \app\models\Database::setDb($db);
             $conn = new \app\inc\Model();

--- a/app/models/Database.php
+++ b/app/models/Database.php
@@ -56,7 +56,8 @@ class Database extends \app\inc\Model
         $sql = "GRANT ALL PRIVILEGES ON DATABASE {$screenName} to {$screenName}";
         $this->execQuery($sql);
 
-        $sql = "GRANT {$screenName} to {$this->postgisuser}";
+        $postgisUser = explode('@', $this->postgisuser)[0];
+        $sql = "GRANT {$screenName} to {$postgisUser}";
         $this->execQuery($sql);
 
         $this->changeOwner($screenName, $screenName);


### PR DESCRIPTION
The migration should be applied to the `template_geocloud` as well; the GC2 should not fail on `user@database` Postgres user format