### PR TITLE
hide server version and os from header and internal error pages and update pgp key for qgis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [CalVer](https://calver.org/).
 
+## [UNRELEASED] - 2022-14-9
+### Added
+- Hide server version and OS from header and internal error pages. For this change to take effect you have to create a new base image.
+- Updated the QGIS gpg.key to 2022 version.
+
 ## [UNRELEASED] - 2022-9-9
 ### Added
 - Two new v3 API's: `api/v3/schema` and `api/v3/meta`, which correspond to the v2 ones (`api/v2/database/schemas` and `api/v2/meta`). The new `meta` does format the data different and let out some legacy properties. Check out swagger page.

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -38,6 +38,10 @@ RUN cd ~ &&\
 # Make php-fpm run in the foreground
 RUN sed 's/;daemonize = yes/daemonize = no/' -i /etc/php/7.3/fpm/php-fpm.conf
 
+# Hide server version and os from header and internal error pages
+RUN sed -i '/ServerTokens OS/c\ServerTokens Prod' /etc/apache2/conf-enabled/security.conf
+RUN sed -i '/ServerSignature On/c\ServerSignature Off' /etc/apache2/conf-enabled/security.conf
+
 # Install Node.js and Grunt
 RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh &&\
     bash nodesource_setup.sh &&\

--- a/docker/mapserver/Dockerfile
+++ b/docker/mapserver/Dockerfile
@@ -49,7 +49,7 @@ RUN cd ~ && \
     ldconfig
 
 # Install QGIS-server
-RUN wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import &&\
+RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import &&\
     chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg &&\
     add-apt-repository "deb https://qgis.org/debian $(lsb_release -c -s) main" &&\
     apt-get update --allow-releaseinfo-change && \
@@ -122,4 +122,3 @@ EXPOSE 443
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-


### PR DESCRIPTION
This pull request is linked to this issue https://github.com/mapcentia/geocloud2/issues/114