### PR TITLE
Update number of keys scanned

### DIFF
--- a/docker/_hacks/drivers/redis/Driver.php
+++ b/docker/_hacks/drivers/redis/Driver.php
@@ -129,7 +129,7 @@ class Driver implements AggregatablePoolInterface
         $keys = [];
         $pattern = $pattern === '' ? '*' : $pattern;
         do {
-            $keys = array_merge($keys, $this->instance->scan($i, $pattern, 10));
+            $keys = array_merge($keys, $this->instance->scan($i, $pattern, 50000));
             if (sizeof($keys) > ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT) {
                 break;
             }


### PR DESCRIPTION
Changed the number of keys scanned to 50000 for a much improved experience in gc2 admin when adjusting settings. the prior value of 10 caused a super high amount of scans, bogging down the redis service