### PR TITLE
Add missing port in connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## Fixed
 - Refactor processArray in `app/models/Sql` to accept mixed type parameter. This was an issue with JSON fields with content with boolean properties.
+- The parameter `postgisport` was not used in some instances. This is now fixed.
 
 ## [2024.12.0] - 2024-2-12
 

--- a/app/api/v4/Import.php
+++ b/app/api/v4/Import.php
@@ -245,7 +245,7 @@ class Import extends AbstractApi
             $fileFullPath = $dir . "/" . $safeName;
         }
         $connectionStr =
-            "\"PG:host=" . Connection::$param["postgishost"] . " user=" . Connection::$param["postgisuser"] . " password=" . Connection::$param["postgispw"] . " dbname=" . Connection::$param["postgisdb"] . "\"";
+            "\"PG:host=" . Connection::$param["postgishost"] . " port=" . Connection::$param["postgisport"] . " user=" . Connection::$param["postgisuser"] . " password=" . Connection::$param["postgispw"] . " dbname=" . Connection::$param["postgisdb"] . "\"";
         $cmd = "ogr2postgis" .
             " --json" .
             ($args && property_exists($args, 's_srs') ? " --s_srs " . $args->s_srs : "") .

--- a/app/controllers/upload/Processvector.php
+++ b/app/controllers/upload/Processvector.php
@@ -153,7 +153,7 @@ class Processvector extends Controller
             // =============================
             ($format == "csv" ? "-oo X_POSSIBLE_NAMES=lon*,Lon*,x,X -oo Y_POSSIBLE_NAMES=lat*,Lat*,y,Y -oo AUTODETECT_TYPE=YES -oo GEOM_POSSIBLE_NAMES=geometri " : '') .
 
-            "-f 'PostgreSQL' PG:'host=" . Connection::$param["postgishost"] . " user=" . Connection::$param["postgisuser"] . " password=" . Connection::$param["postgispw"] . " dbname=" . Connection::$param["postgisdb"] . "' " .
+            "-f 'PostgreSQL' PG:'host=" . Connection::$param["postgishost"] . " port=" . Connection::$param["postgisport"] . " user=" . Connection::$param["postgisuser"] . " password=" . Connection::$param["postgispw"] . " dbname=" . Connection::$param["postgisdb"] . "' " .
             "'" . $dir . "/" . $fileName . "' " .
             "-nln " . Connection::$param["postgisschema"] . ".$safeName -nlt $type";
 

--- a/app/models/Sql.php
+++ b/app/models/Sql.php
@@ -103,7 +103,7 @@ class Sql extends Model
                 ($nln ? "-nln " . $nln . " " : "") .
                 "-preserve_fid " .
                 ($format == "ogr/GPX" ? "-lco 'FORCE_GPX_ROUTE=YES' " : "") .
-                "PG:'host=" . Connection::$param["postgishost"] . " user=" . Connection::$param["postgisuser"] . " password=" . Connection::$param["postgispw"] . " dbname=" . Connection::$param["postgisdb"] . "' " .
+                "PG:'host=" . Connection::$param["postgishost"] . " port=" . Connection::$param["postgisport"] . " user=" . Connection::$param["postgisuser"] . " password=" . Connection::$param["postgispw"] . " dbname=" . Connection::$param["postgisdb"] . "' " .
                 "-sql \"" . $q . "\"";
 //            die($cmd);
             exec($cmd . ' 2>&1', $out);


### PR DESCRIPTION
When setting the connection string, port was sometimes omitted. this works fine if using standard ports - not if you are using a custom port.