### PR TITLE
Allow headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [CalVer](https://calver.org/).
 
+## Unreleased
+### Fixed
+- Added `GC2-API-KEY` to `Access-Control-Allow-Headers` to remove an error when calling feature-api and more from CORS-strict clients such as browsers.
+
 ## [2025.7.0] - 2025-8-7
 ### Added
 - New v4 API `api/v4/sql/database/[database]` which can be used without a token.

--- a/public/index.php
+++ b/public/index.php
@@ -131,7 +131,7 @@ if (isset(App::$param["AccessControlAllowOrigin"]) && in_array($http_origin, App
 } elseif (isset(App::$param["AccessControlAllowOrigin"]) && App::$param["AccessControlAllowOrigin"][0] == "*") {
     header("Access-Control-Allow-Origin: *");
 }
-header("Access-Control-Allow-Headers: Origin, Content-Type, Authorization, X-Requested-With, Accept, Session, Cache-Control");
+header("Access-Control-Allow-Headers: Origin, Content-Type, Authorization, X-Requested-With, Accept, Session, Cache-Control, GC2-API-KEY");
 header("Access-Control-Allow-Credentials: true");
 header("Access-Control-Allow-Methods: GET, PUT, POST, DELETE, HEAD, OPTIONS");
 


### PR DESCRIPTION
This pull request addresses a CORS-related issue by adding support for the `GC2-API-KEY` header. This change ensures compatibility with stricter CORS policies in client applications, such as browsers.

### CORS Compatibility Fixes:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11): Documented the addition of `GC2-API-KEY` to `Access-Control-Allow-Headers` to resolve errors encountered by CORS-strict clients.
* [`public/index.php`](diffhunk://#diff-ab1615a3a159df0750aa7b76472124966ab3076c26abcd050f6b9120fbda6c61L134-R134): Updated the `Access-Control-Allow-Headers` configuration to include `GC2-API-KEY`, allowing CORS-strict clients to function correctly.